### PR TITLE
Update accord version to ^0.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/Munter/tolk",
   "dependencies": {
-    "accord": "^0.18.0",
+    "accord": "^0.20.0",
     "autoprefixer-core": "^5.2.0",
     "inline-source-map-comment": "^1.0.5",
     "postcss": "^4.1.11",


### PR DESCRIPTION
Gets multi-version support for `node-sass` - fixes Munter/fusile#19 but down to whether you want to keep using accord at all :D Fixes it for now though so _shrug_.
