### PR TITLE
remove unused dependency mocha-lcov-reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "less": "2.6.1",
     "marked": "0.3.5",
     "mocha": "2.4.5",
-    "mocha-lcov-reporter": "1.0.0",
     "myth": "1.5.0",
     "node-sass": "3.4.2",
     "stylus": "0.54.2",


### PR DESCRIPTION
As far as I can see this havent been used anywhere, since it was committed in the initial commit. I guess it's a leftover...

Hoping for the travis build to confirm my suspicion. :-)
